### PR TITLE
Feat : hidden_markov_model

### DIFF
--- a/quantitative_finance/hidden_markov_model.r
+++ b/quantitative_finance/hidden_markov_model.r
@@ -120,9 +120,14 @@ HMM <- R6Class("HMM",
     get_regime_labels = function() {
       regime_names <- character(self$n_states)
       sorted_means <- sort(self$emission_means, index.return = TRUE)
-      
-      if (self$n_states == 2) {
-        regime_names[sorted_means$ix[1]] <- "Bear"
+      eig <- eigen(t(self$transition_matrix))
+      # Find the eigenvalue closest to 1
+      idx <- which.min(abs(eig$values - 1))
+      steady_state <- Re(eig$vectors[, idx])
+      # Ensure non-negative and normalize
+      steady_state <- steady_state / sum(steady_state)
+      steady_state[steady_state < 0] <- 0
+      steady_state <- steady_state / sum(steady_state)
         regime_names[sorted_means$ix[2]] <- "Bull"
       } else if (self$n_states == 3) {
         regime_names[sorted_means$ix[1]] <- "Bear"


### PR DESCRIPTION
# **Hidden Markov Model (HMM) – Quant Finance Overview**

## **Purpose**
Captures **regime switching** in financial markets — for example, transitions between **bull** and **bear** states.

---

## **Key Idea**
The market is treated as a **latent state machine**, where:
- Each hidden state represents a **market regime**
- Each state has its own **probability distribution** of returns
- The model learns **transition probabilities** between regimes

Mathematically:
\[
P(S_t | S_{t-1}) = A_{ij}, \quad P(O_t | S_t) = B_j(O_t)
\]
where  
- \( S_t \): hidden state at time *t*  
- \( O_t \): observed return at time *t*  
- \( A_{ij} \): transition probability between states  
- \( B_j \): emission probability for observations  

---

## **Use Cases**
- Detecting **market regimes**
- Forecasting **volatility states**
- Generating **algorithmic trading signals**

---

## **Minimal R Implementation**
```r
# Install dependencies
install.packages("depmixS4")

# Load library
library(depmixS4)

# Example: 2-state HMM on daily returns
set.seed(123)
returns <- diff(log(EuStockMarkets[, "DAX"]))  # sample data

# Build model
model <- depmix(response = returns ~ 1, 
                family = gaussian(), 
                nstates = 2, 
                data = data.frame(returns = returns))

# Fit model
fit_model <- fit(model)

# View results
summary(fit_model)

# Decode states (bull/bear)
states <- posterior(fit_model)
head(states)